### PR TITLE
Add category icons and component

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-<url><loc>https://www.zinglots.com/</loc><lastmod>2025-08-28T03:29:07.097Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/auctions</loc><lastmod>2025-08-28T03:29:07.097Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/discover</loc><lastmod>2025-08-28T03:29:07.097Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/pricing</loc><lastmod>2025-08-28T03:29:07.097Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/help</loc><lastmod>2025-08-28T03:29:07.097Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/sellers</loc><lastmod>2025-08-28T03:29:07.097Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/r/seattle</loc><lastmod>2025-08-28T03:29:07.097Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/r/tacoma</loc><lastmod>2025-08-28T03:29:07.097Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/r/los-angeles</loc><lastmod>2025-08-28T03:29:07.097Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/r/chicago</loc><lastmod>2025-08-28T03:29:07.097Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/product/s1</loc><lastmod>2025-08-28T03:29:07.097Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/product/s2</loc><lastmod>2025-08-28T03:29:07.097Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/product/s3</loc><lastmod>2025-08-28T03:29:07.097Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/product/show1</loc><lastmod>2025-08-28T03:29:07.097Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/product/show2</loc><lastmod>2025-08-28T03:29:07.097Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/product/lot-${i + 1}</loc><lastmod>2025-08-28T03:29:07.097Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/</loc><lastmod>2025-08-28T03:50:43.680Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/auctions</loc><lastmod>2025-08-28T03:50:43.680Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/discover</loc><lastmod>2025-08-28T03:50:43.680Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/pricing</loc><lastmod>2025-08-28T03:50:43.680Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/help</loc><lastmod>2025-08-28T03:50:43.680Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/sellers</loc><lastmod>2025-08-28T03:50:43.680Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/r/seattle</loc><lastmod>2025-08-28T03:50:43.680Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/r/tacoma</loc><lastmod>2025-08-28T03:50:43.680Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/r/los-angeles</loc><lastmod>2025-08-28T03:50:43.680Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/r/chicago</loc><lastmod>2025-08-28T03:50:43.680Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/product/s1</loc><lastmod>2025-08-28T03:50:43.680Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/product/s2</loc><lastmod>2025-08-28T03:50:43.680Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/product/s3</loc><lastmod>2025-08-28T03:50:43.680Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/product/show1</loc><lastmod>2025-08-28T03:50:43.680Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/product/show2</loc><lastmod>2025-08-28T03:50:43.680Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/product/lot-${i + 1}</loc><lastmod>2025-08-28T03:50:43.680Z</lastmod><priority>0.7</priority></url>
 </urlset>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-<url><loc>https://www.zinglots.com/</loc><lastmod>2025-08-28T02:25:27.907Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/auctions</loc><lastmod>2025-08-28T02:25:27.907Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/discover</loc><lastmod>2025-08-28T02:25:27.907Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/pricing</loc><lastmod>2025-08-28T02:25:27.907Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/help</loc><lastmod>2025-08-28T02:25:27.907Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/sellers</loc><lastmod>2025-08-28T02:25:27.907Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/r/seattle</loc><lastmod>2025-08-28T02:25:27.907Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/r/tacoma</loc><lastmod>2025-08-28T02:25:27.907Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/r/los-angeles</loc><lastmod>2025-08-28T02:25:27.907Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/r/chicago</loc><lastmod>2025-08-28T02:25:27.907Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/product/s1</loc><lastmod>2025-08-28T02:25:27.907Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/product/s2</loc><lastmod>2025-08-28T02:25:27.907Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/product/s3</loc><lastmod>2025-08-28T02:25:27.907Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/product/show1</loc><lastmod>2025-08-28T02:25:27.907Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/product/show2</loc><lastmod>2025-08-28T02:25:27.907Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/product/lot-${i + 1}</loc><lastmod>2025-08-28T02:25:27.907Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/</loc><lastmod>2025-08-28T03:29:07.097Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/auctions</loc><lastmod>2025-08-28T03:29:07.097Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/discover</loc><lastmod>2025-08-28T03:29:07.097Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/pricing</loc><lastmod>2025-08-28T03:29:07.097Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/help</loc><lastmod>2025-08-28T03:29:07.097Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/sellers</loc><lastmod>2025-08-28T03:29:07.097Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/r/seattle</loc><lastmod>2025-08-28T03:29:07.097Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/r/tacoma</loc><lastmod>2025-08-28T03:29:07.097Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/r/los-angeles</loc><lastmod>2025-08-28T03:29:07.097Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/r/chicago</loc><lastmod>2025-08-28T03:29:07.097Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/product/s1</loc><lastmod>2025-08-28T03:29:07.097Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/product/s2</loc><lastmod>2025-08-28T03:29:07.097Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/product/s3</loc><lastmod>2025-08-28T03:29:07.097Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/product/show1</loc><lastmod>2025-08-28T03:29:07.097Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/product/show2</loc><lastmod>2025-08-28T03:29:07.097Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/product/lot-${i + 1}</loc><lastmod>2025-08-28T03:29:07.097Z</lastmod><priority>0.7</priority></url>
 </urlset>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-<url><loc>https://www.zinglots.com/</loc><lastmod>2025-08-28T03:50:43.680Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/auctions</loc><lastmod>2025-08-28T03:50:43.680Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/discover</loc><lastmod>2025-08-28T03:50:43.680Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/pricing</loc><lastmod>2025-08-28T03:50:43.680Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/help</loc><lastmod>2025-08-28T03:50:43.680Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/sellers</loc><lastmod>2025-08-28T03:50:43.680Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/r/seattle</loc><lastmod>2025-08-28T03:50:43.680Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/r/tacoma</loc><lastmod>2025-08-28T03:50:43.680Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/r/los-angeles</loc><lastmod>2025-08-28T03:50:43.680Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/r/chicago</loc><lastmod>2025-08-28T03:50:43.680Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/product/s1</loc><lastmod>2025-08-28T03:50:43.680Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/product/s2</loc><lastmod>2025-08-28T03:50:43.680Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/product/s3</loc><lastmod>2025-08-28T03:50:43.680Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/product/show1</loc><lastmod>2025-08-28T03:50:43.680Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/product/show2</loc><lastmod>2025-08-28T03:50:43.680Z</lastmod><priority>0.7</priority></url>
-<url><loc>https://www.zinglots.com/product/lot-${i + 1}</loc><lastmod>2025-08-28T03:50:43.680Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/</loc><lastmod>2025-08-28T04:05:45.687Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/auctions</loc><lastmod>2025-08-28T04:05:45.687Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/discover</loc><lastmod>2025-08-28T04:05:45.687Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/pricing</loc><lastmod>2025-08-28T04:05:45.687Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/help</loc><lastmod>2025-08-28T04:05:45.687Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/sellers</loc><lastmod>2025-08-28T04:05:45.687Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/r/seattle</loc><lastmod>2025-08-28T04:05:45.687Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/r/tacoma</loc><lastmod>2025-08-28T04:05:45.687Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/r/los-angeles</loc><lastmod>2025-08-28T04:05:45.687Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/r/chicago</loc><lastmod>2025-08-28T04:05:45.687Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/product/s1</loc><lastmod>2025-08-28T04:05:45.687Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/product/s2</loc><lastmod>2025-08-28T04:05:45.687Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/product/s3</loc><lastmod>2025-08-28T04:05:45.687Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/product/show1</loc><lastmod>2025-08-28T04:05:45.687Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/product/show2</loc><lastmod>2025-08-28T04:05:45.687Z</lastmod><priority>0.7</priority></url>
+<url><loc>https://www.zinglots.com/product/lot-${i + 1}</loc><lastmod>2025-08-28T04:05:45.687Z</lastmod><priority>0.7</priority></url>
 </urlset>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ const ExplorePage = lazy(() => import("./pages/explore"));
 const Accessibility = lazy(() => import("./pages/Accessibility"));
 const Sitemap = lazy(() => import("./pages/Sitemap"));
 const Security = lazy(() => import("./pages/Security"));
+const IconDemo = lazy(() => import("./routes/icon-demo"));
 
 // B2B Marketplace Pages
 const RegionPage = lazy(() => import("./pages/RegionPage"));
@@ -109,6 +110,7 @@ const App = () => (
                   <Route path="/admin/review-sellers" element={<ReviewSellers />} />
                   <Route path="/qa" element={<QA />} />
                   <Route path="/login" element={<Login />} />
+                  <Route path="/icon-demo" element={<IconDemo />} />
                   
                   {/* Fixed routes - auction detail and live room separated */}
                   <Route

--- a/src/components/CategoryIcon.tsx
+++ b/src/components/CategoryIcon.tsx
@@ -27,8 +27,15 @@ const CategoryIcon: React.FC<CategoryIconProps> = ({ name, className, alt }) => 
       height={128}
       loading="lazy"
       decoding="async"
-      className={className}
+      className={["object-contain", className].filter(Boolean).join(" ")}
       alt={alt ?? name}
+      onError={(e) => {
+        const target = e.currentTarget as HTMLImageElement;
+        if (!target?.dataset?.fallback) {
+          target.src = "/icons/zinglots-icon.svg";
+          target.dataset.fallback = "true";
+        }
+      }}
     />
   );
 };

--- a/src/components/CategoryIcon.tsx
+++ b/src/components/CategoryIcon.tsx
@@ -20,10 +20,16 @@ export type CategoryIconProps = {
 
 const CategoryIcon: React.FC<CategoryIconProps> = ({ name, className, alt }) => {
   const candidates = useMemo(() => [
+    // Primary app public path
     `/icons/${name}_128.png`,
     `/icons/${name}-128.png`,
     `/icons/${name}128.png`,
     `/icons/${name}.png`,
+    // Temporary fallback: files uploaded under ZingLots.com/public/icons
+    `/ZingLots.com/public/icons/${name}_128.png`,
+    `/ZingLots.com/public/icons/${name}-128.png`,
+    `/ZingLots.com/public/icons/${name}128.png`,
+    `/ZingLots.com/public/icons/${name}.png`,
   ], [name]);
 
   const [candidateIndex, setCandidateIndex] = useState(0);

--- a/src/components/CategoryIcon.tsx
+++ b/src/components/CategoryIcon.tsx
@@ -29,13 +29,6 @@ const CategoryIcon: React.FC<CategoryIconProps> = ({ name, className, alt }) => 
       decoding="async"
       className={["object-contain", className].filter(Boolean).join(" ")}
       alt={alt ?? name}
-      onError={(e) => {
-        const target = e.currentTarget as HTMLImageElement;
-        if (!target?.dataset?.fallback) {
-          target.src = "/icons/zinglots-icon.svg";
-          target.dataset.fallback = "true";
-        }
-      }}
     />
   );
 };

--- a/src/components/CategoryIcon.tsx
+++ b/src/components/CategoryIcon.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo, useState } from "react";
 
 export type CategoryIconName =
   | "anvil"
@@ -19,7 +19,16 @@ export type CategoryIconProps = {
 };
 
 const CategoryIcon: React.FC<CategoryIconProps> = ({ name, className, alt }) => {
-  const src = `/icons/${name}_128.png`;
+  const candidates = useMemo(() => [
+    `/icons/${name}_128.png`,
+    `/icons/${name}-128.png`,
+    `/icons/${name}128.png`,
+    `/icons/${name}.png`,
+  ], [name]);
+
+  const [candidateIndex, setCandidateIndex] = useState(0);
+  const src = candidates[Math.min(candidateIndex, candidates.length - 1)];
+
   return (
     <img
       src={src}
@@ -29,6 +38,9 @@ const CategoryIcon: React.FC<CategoryIconProps> = ({ name, className, alt }) => 
       decoding="async"
       className={["object-contain", className].filter(Boolean).join(" ")}
       alt={alt ?? name}
+      onError={() => {
+        setCandidateIndex((prev) => (prev + 1 < candidates.length ? prev + 1 : prev));
+      }}
     />
   );
 };

--- a/src/components/CategoryIcon.tsx
+++ b/src/components/CategoryIcon.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+
+export type CategoryIconName =
+  | "anvil"
+  | "cutlery"
+  | "shirt"
+  | "bulldozer"
+  | "briefcase"
+  | "dumbbells"
+  | "sofa"
+  | "flask"
+  | "ring"
+  | "wrench";
+
+export type CategoryIconProps = {
+  name: CategoryIconName;
+  className?: string;
+  alt?: string;
+};
+
+const CategoryIcon: React.FC<CategoryIconProps> = ({ name, className, alt }) => {
+  const src = `/icons/${name}_128.png`;
+  return (
+    <img
+      src={src}
+      width={128}
+      height={128}
+      loading="lazy"
+      decoding="async"
+      className={className}
+      alt={alt ?? name}
+    />
+  );
+};
+
+export default CategoryIcon;
+

--- a/src/pages/Categories.tsx
+++ b/src/pages/Categories.tsx
@@ -3,24 +3,38 @@ import { Link } from "react-router-dom";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Building2, UtensilsCrossed, Briefcase, Wrench, Heart, Home, Shirt, Dumbbell, Anvil, Diamond } from "lucide-react";
+import CategoryIcon, { type CategoryIconName } from "@/components/CategoryIcon";
 
 const Categories = () => {
   const categories = [
-    { id: "construction-materials", name: "Construction", icon: Building2, count: 342 },
-    { id: "restaurant-equipment", name: "Restaurant", icon: UtensilsCrossed, count: 189 },
-    { id: "office-furniture", name: "Office", icon: Briefcase, count: 156 },
-    { id: "municipal-surplus", name: "Municipal", icon: Wrench, count: 98 },
-    { id: "blacksmithing", name: "Blacksmithing", icon: Anvil, count: 24 },
-    { id: "jewelry-making", name: "Jewelry Making", icon: Diamond, count: 41 }
+    { id: "construction-materials", name: "Construction", count: 342 },
+    { id: "restaurant-equipment", name: "Restaurant", count: 189 },
+    { id: "office-furniture", name: "Office", count: 156 },
+    { id: "municipal-surplus", name: "Municipal", count: 98 },
+    { id: "blacksmithing", name: "Blacksmithing", count: 24 },
+    { id: "jewelry-making", name: "Jewelry Making", count: 41 }
   ];
 
   const additionalCategories = [
-    { id: "medical-lab", name: "Medical & Lab", icon: Heart, count: 67 },
-    { id: "home-furniture", name: "Home Furniture", icon: Home, count: 89 },
-    { id: "apparel-textiles", name: "Apparel & Textiles", icon: Shirt, count: 45 },
-    { id: "fitness-sports", name: "Fitness & Sports", icon: Dumbbell, count: 78 }
+    { id: "medical-lab", name: "Medical & Lab", count: 67 },
+    { id: "home-furniture", name: "Home Furniture", count: 89 },
+    { id: "apparel-textiles", name: "Apparel & Textiles", count: 45 },
+    { id: "fitness-sports", name: "Fitness & Sports", count: 78 }
   ];
+
+  const idToIconName: Record<string, CategoryIconName> = {
+    "construction-materials": "bulldozer",
+    "restaurant-equipment": "cutlery",
+    "office-furniture": "briefcase",
+    "municipal-surplus": "wrench",
+    "industrial-equipment": "wrench",
+    "blacksmithing": "anvil",
+    "jewelry-making": "ring",
+    "medical-lab": "flask",
+    "home-furniture": "sofa",
+    "apparel-textiles": "shirt",
+    "fitness-sports": "dumbbells",
+  };
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -55,10 +69,12 @@ const Categories = () => {
           {categories.map((cat) => (
             <Card key={cat.id} className="hover:shadow-lg transition">
               <CardContent className="p-6">
-                <div className="flex items-center gap-3 mb-3">
-                  <cat.icon className="h-6 w-6 text-brand-red" />
+                <div className="flex flex-col items-center justify-center gap-2 mb-3">
+                  <div className="aspect-square w-20 flex items-center justify-center">
+                    <CategoryIcon name={idToIconName[cat.id]} className="h-16 w-16" alt={cat.name} />
+                  </div>
                   <h3 className="font-semibold">{cat.name}</h3>
-                  <Badge variant="secondary" className="ml-auto">{cat.count}</Badge>
+                  <Badge variant="secondary">{cat.count}</Badge>
                 </div>
                 <Button asChild variant="outline" className="w-full">
                   <Link to={`/category/${cat.id}`}>Browse {cat.name}</Link>
@@ -73,10 +89,12 @@ const Categories = () => {
           {additionalCategories.map((cat) => (
             <Card key={cat.id} className="hover:shadow-lg transition">
               <CardContent className="p-6">
-                <div className="flex items-center gap-3 mb-3">
-                  <cat.icon className="h-6 w-6 text-brand-red" />
+                <div className="flex flex-col items-center justify-center gap-2 mb-3">
+                  <div className="aspect-square w-20 flex items-center justify-center">
+                    <CategoryIcon name={idToIconName[cat.id]} className="h-16 w-16" alt={cat.name} />
+                  </div>
                   <h3 className="font-semibold">{cat.name}</h3>
-                  <Badge variant="secondary" className="ml-auto">{cat.count}</Badge>
+                  <Badge variant="secondary">{cat.count}</Badge>
                 </div>
                 <Button asChild variant="outline" className="w-full">
                   <Link to={`/category/${cat.id}`}>Browse {cat.name}</Link>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -12,7 +12,8 @@ import PayPalSmokeTest from "@/components/PayPalSmokeTest";
 
 import { useState, useMemo } from "react";
 import { SearchBar } from "@/components/ui/search-bar";
-import { Building2, UtensilsCrossed, Briefcase, Wrench, MapPin, Truck, Shield, Clock } from "lucide-react";
+import { MapPin, Truck, Shield, Clock } from "lucide-react";
+import CategoryIcon, { type CategoryIconName } from "@/components/CategoryIcon";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Hero } from "@/components/Hero";
@@ -53,7 +54,6 @@ const Index = () => {
     {
       id: "contractor",
       name: "Construction & Materials",
-      icon: Building2,
       description: "Lumber, tools, heavy equipment",
       count: 342,
       color: "bg-orange-100 text-orange-800"
@@ -61,7 +61,6 @@ const Index = () => {
     {
       id: "restaurant",
       name: "Restaurant & Food Service",
-      icon: UtensilsCrossed,
       description: "Commercial ovens, refrigeration, furniture",
       count: 189,
       color: "bg-green-100 text-green-800"
@@ -69,7 +68,6 @@ const Index = () => {
     {
       id: "office",
       name: "Office & Business Equipment",
-      icon: Briefcase,
       description: "Furniture, computers, office supplies",
       count: 156,
       color: "bg-blue-100 text-blue-800"
@@ -77,12 +75,18 @@ const Index = () => {
     {
       id: "municipal",
       name: "Government & Municipal Surplus",
-      icon: Wrench,
       description: "Vehicles, equipment, furniture",
       count: 98,
       color: "bg-purple-100 text-purple-800"
     }
   ];
+
+  const idToIconNameLegacy: Record<string, CategoryIconName> = {
+    contractor: "bulldozer",
+    restaurant: "cutlery",
+    office: "briefcase",
+    municipal: "wrench",
+  };
 
   const featuredLots = [
     {
@@ -239,12 +243,11 @@ const Index = () => {
           <h2 className="text-3xl font-bold text-center mb-12 text-[#0f172a]">Browse by Category</h2>
           <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
             {categories.map((category) => {
-              const IconComponent = category.icon;
               return (
                 <Card key={category.id} className="hover:shadow-lg transition-shadow cursor-pointer">
                   <CardHeader>
                     <div className="flex items-center justify-between">
-                      <IconComponent className="h-8 w-8 text-[#64748b]" />
+                      <CategoryIcon name={idToIconNameLegacy[category.id]} className="h-8 w-8" alt={category.name} />
                       <Badge className={category.color}>
                         {category.count} lots
                       </Badge>

--- a/src/pages/ModernIndex.tsx
+++ b/src/pages/ModernIndex.tsx
@@ -19,14 +19,9 @@ import {
   Gavel,
   Package,
   Users,
-  Building2,
-  UtensilsCrossed,
-  Briefcase,
-  Wrench,
-  Anvil,
-  Diamond,
   ArrowRight
 } from "lucide-react";
+import CategoryIcon, { type CategoryIconName } from "@/components/CategoryIcon";
 import "../styles/modern-design.css";
 import HeroShowcase, { type HeroSlide as HeroShowcaseSlide } from "@/components/HeroShowcase";
 import FeaturedAuctionsMarquee, { type AuctionPromo } from "@/features/auctions/FeaturedAuctionsMarquee";
@@ -107,51 +102,22 @@ const ModernIndex = () => {
 
   // Categories with icons and colors
   const categories = [
-    {
-      id: "construction-materials",
-      name: "Construction",
-      icon: Building2,
-      count: 342,
-      color: "from-orange-500 to-red-500",
-      trending: true
-    },
-    {
-      id: "restaurant-equipment",
-      name: "Restaurant",
-      icon: UtensilsCrossed,
-      count: 189,
-      color: "from-green-500 to-emerald-500"
-    },
-    {
-      id: "office-furniture",
-      name: "Office",
-      icon: Briefcase,
-      count: 156,
-      color: "from-blue-500 to-indigo-500"
-    },
-    {
-      id: "municipal-surplus",
-      name: "Municipal",
-      icon: Wrench,
-      count: 98,
-      color: "from-purple-500 to-pink-500"
-    }
-    ,
-    {
-      id: "blacksmithing",
-      name: "Blacksmithing",
-      icon: Anvil,
-      count: 24,
-      color: "from-stone-600 to-stone-800"
-    },
-    {
-      id: "jewelry-making",
-      name: "Jewelry Making",
-      icon: Diamond,
-      count: 41,
-      color: "from-rose-500 to-pink-500"
-    }
+    { id: "construction-materials", name: "Construction", count: 342, color: "from-orange-500 to-red-500", trending: true },
+    { id: "restaurant-equipment", name: "Restaurant", count: 189, color: "from-green-500 to-emerald-500" },
+    { id: "office-furniture", name: "Office", count: 156, color: "from-blue-500 to-indigo-500" },
+    { id: "municipal-surplus", name: "Municipal", count: 98, color: "from-purple-500 to-pink-500" },
+    { id: "blacksmithing", name: "Blacksmithing", count: 24, color: "from-stone-600 to-stone-800" },
+    { id: "jewelry-making", name: "Jewelry Making", count: 41, color: "from-rose-500 to-pink-500" }
   ];
+
+  const idToIconName: Record<string, CategoryIconName> = {
+    "construction-materials": "bulldozer",
+    "restaurant-equipment": "cutlery",
+    "office-furniture": "briefcase",
+    "municipal-surplus": "wrench",
+    "blacksmithing": "anvil",
+    "jewelry-making": "ring",
+  };
 
   // Featured lots data - Active Auctions
   const featuredLots = [
@@ -379,7 +345,6 @@ const ModernIndex = () => {
           
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
             {categories.map((category) => {
-              const IconComponent = category.icon;
               return (
                 <Link
                   key={category.id}
@@ -389,7 +354,7 @@ const ModernIndex = () => {
                   <div className={`absolute inset-0 bg-gradient-to-br ${category.color} opacity-0 group-hover:opacity-10 transition-opacity`} />
                   <div className="p-6">
                     <div className="flex justify-between items-start mb-4">
-                      <IconComponent className="h-10 w-10 text-gray-700 group-hover:text-brand-red transition-colors" />
+                      <CategoryIcon name={idToIconName[category.id]} className="h-10 w-10" alt={category.name} />
                       {category.trending && (
                         <Badge className="badge-hot">Trending</Badge>
                       )}

--- a/src/routes/icon-demo.tsx
+++ b/src/routes/icon-demo.tsx
@@ -1,0 +1,35 @@
+import CategoryIcon, { type CategoryIconName } from "@/components/CategoryIcon";
+
+const ICONS: CategoryIconName[] = [
+  "anvil",
+  "cutlery",
+  "shirt",
+  "bulldozer",
+  "briefcase",
+  "dumbbells",
+  "sofa",
+  "flask",
+  "ring",
+  "wrench",
+];
+
+const IconDemo = () => {
+  return (
+    <div className="max-w-5xl mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-6">Category Icons Demo</h1>
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-6">
+        {ICONS.map((name) => (
+          <div key={name} className="flex flex-col items-center gap-2">
+            <div className="aspect-square w-24 flex items-center justify-center rounded-md border bg-white">
+              <CategoryIcon name={name} className="h-20 w-20" />
+            </div>
+            <div className="text-sm text-muted-foreground">{name}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default IconDemo;
+


### PR DESCRIPTION
Introduce a `CategoryIcon` component and integrate it into category buttons on key pages, replacing existing Lucide icons, to provide custom visual representation.

The icon image assets are not included in this PR, as the `icons-10-transparent-128.zip` file was not available during the session. A follow-up PR will add these assets to `public/icons/`. This PR sets up the component and integration points, along with a demo page for easy verification once the assets are in place.

---
<a href="https://cursor.com/background-agent?bcId=bc-7f524928-4cf6-452e-895d-422e944a0c7f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7f524928-4cf6-452e-895d-422e944a0c7f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

