### PR TITLE
Fetch cutlery icon from ZingLots

### DIFF
--- a/src/pages/Categories.tsx
+++ b/src/pages/Categories.tsx
@@ -8,7 +8,7 @@ import { Building2, UtensilsCrossed, Briefcase, Wrench, Heart, Home, Shirt, Dumb
 const Categories = () => {
   const categories = [
     { id: "construction-materials", name: "Construction", icon: Building2, count: 342 },
-    { id: "restaurant-equipment", name: "Restaurant", icon: UtensilsCrossed, count: 189 },
+    { id: "restaurant-equipment", name: "Restaurant", icon: "/icons/cutlery_128.png", isImage: true, count: 189 },
     { id: "office-furniture", name: "Office", icon: Briefcase, count: 156 },
     { id: "municipal-surplus", name: "Municipal", icon: Wrench, count: 98 },
     { id: "blacksmithing", name: "Blacksmithing", icon: Anvil, count: 24 },
@@ -52,38 +52,60 @@ const Categories = () => {
       {/* Categories Grid */}
       <div className="max-w-7xl mx-auto px-4 py-8">
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-          {categories.map((cat) => (
-            <Card key={cat.id} className="hover:shadow-lg transition">
-              <CardContent className="p-6">
-                <div className="flex items-center gap-3 mb-3">
-                  <cat.icon className="h-6 w-6 text-brand-red" />
-                  <h3 className="font-semibold">{cat.name}</h3>
-                  <Badge variant="secondary" className="ml-auto">{cat.count}</Badge>
-                </div>
-                <Button asChild variant="outline" className="w-full">
-                  <Link to={`/category/${cat.id}`}>Browse {cat.name}</Link>
-                </Button>
-              </CardContent>
-            </Card>
-          ))}
+          {categories.map((cat) => {
+            const IconComponent = cat.isImage ? null : cat.icon;
+            return (
+              <Card key={cat.id} className="hover:shadow-lg transition">
+                <CardContent className="p-6">
+                  <div className="flex items-center gap-3 mb-3">
+                    {cat.isImage ? (
+                      <img 
+                        src={cat.icon} 
+                        alt={`${cat.name} icon`}
+                        className="h-6 w-6 object-contain"
+                      />
+                    ) : (
+                      <IconComponent className="h-6 w-6 text-brand-red" />
+                    )}
+                    <h3 className="font-semibold">{cat.name}</h3>
+                    <Badge variant="secondary" className="ml-auto">{cat.count}</Badge>
+                  </div>
+                  <Button asChild variant="outline" className="w-full">
+                    <Link to={`/category/${cat.id}`}>Browse {cat.name}</Link>
+                  </Button>
+                </CardContent>
+              </Card>
+            );
+          })}
         </div>
 
         <h2 className="text-2xl font-bold mt-12 mb-6">More Categories</h2>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-          {additionalCategories.map((cat) => (
-            <Card key={cat.id} className="hover:shadow-lg transition">
-              <CardContent className="p-6">
-                <div className="flex items-center gap-3 mb-3">
-                  <cat.icon className="h-6 w-6 text-brand-red" />
-                  <h3 className="font-semibold">{cat.name}</h3>
-                  <Badge variant="secondary" className="ml-auto">{cat.count}</Badge>
-                </div>
-                <Button asChild variant="outline" className="w-full">
-                  <Link to={`/category/${cat.id}`}>Browse {cat.name}</Link>
-                </Button>
-              </CardContent>
-            </Card>
-          ))}
+          {additionalCategories.map((cat) => {
+            const IconComponent = cat.isImage ? null : cat.icon;
+            return (
+              <Card key={cat.id} className="hover:shadow-lg transition">
+                <CardContent className="p-6">
+                  <div className="flex items-center gap-3 mb-3">
+                    {cat.isImage ? (
+                      <img 
+                        src={cat.icon} 
+                        alt={`${cat.name} icon`}
+                        className="h-6 w-6 object-contain"
+                      />
+                    ) : (
+                      <IconComponent className="h-6 w-6 text-brand-red" />
+                    )}
+                    <h3 className="font-semibold">{cat.name}</h3>
+                    <Badge variant="secondary" className="ml-auto">{cat.count}</Badge>
+                  </div>
+                  <Button asChild variant="outline" className="w-full">
+                    <Link to={`/category/${cat.id}`}>Browse {cat.name}</Link>
+                  </Button>
+                </CardContent>
+              </Card>
+            );
+          })}
         </div>
       </div>
     </div>

--- a/src/pages/Categories.tsx
+++ b/src/pages/Categories.tsx
@@ -7,19 +7,19 @@ import { Building2, UtensilsCrossed, Briefcase, Wrench, Heart, Home, Shirt, Dumb
 
 const Categories = () => {
   const categories = [
-    { id: "construction-materials", name: "Construction", icon: Building2, count: 342 },
+    { id: "construction-materials", name: "Construction", icon: "/icons/bulldozer_128.png", isImage: true, count: 342 },
     { id: "restaurant-equipment", name: "Restaurant", icon: "/icons/cutlery_128.png", isImage: true, count: 189 },
-    { id: "office-furniture", name: "Office", icon: Briefcase, count: 156 },
-    { id: "municipal-surplus", name: "Municipal", icon: Wrench, count: 98 },
-    { id: "blacksmithing", name: "Blacksmithing", icon: Anvil, count: 24 },
-    { id: "jewelry-making", name: "Jewelry Making", icon: Diamond, count: 41 }
+    { id: "office-furniture", name: "Office", icon: "/icons/briefcase_128.png", isImage: true, count: 156 },
+    { id: "municipal-surplus", name: "Municipal", icon: "/icons/wrench_128.png", isImage: true, count: 98 },
+    { id: "blacksmithing", name: "Blacksmithing", icon: "/icons/anvil_128.png", isImage: true, count: 24 },
+    { id: "jewelry-making", name: "Jewelry Making", icon: "/icons/ring_128.png", isImage: true, count: 41 }
   ];
 
   const additionalCategories = [
-    { id: "medical-lab", name: "Medical & Lab", icon: Heart, count: 67 },
-    { id: "home-furniture", name: "Home Furniture", icon: Home, count: 89 },
-    { id: "apparel-textiles", name: "Apparel & Textiles", icon: Shirt, count: 45 },
-    { id: "fitness-sports", name: "Fitness & Sports", icon: Dumbbell, count: 78 }
+    { id: "medical-lab", name: "Medical & Lab", icon: "/icons/flask_128.png", isImage: true, count: 67 },
+    { id: "home-furniture", name: "Home Furniture", icon: "/icons/sofa_128.png", isImage: true, count: 89 },
+    { id: "apparel-textiles", name: "Apparel & Textiles", icon: "/icons/shirt_128.png", isImage: true, count: 45 },
+    { id: "fitness-sports", name: "Fitness & Sports", icon: "/icons/dumbbells_128.png", isImage: true, count: 78 }
   ];
 
   return (

--- a/src/pages/ModernIndex.tsx
+++ b/src/pages/ModernIndex.tsx
@@ -156,6 +156,22 @@ const ModernIndex = () => {
       isImage: true,
       count: 41,
       color: "from-rose-500 to-pink-500"
+    },
+    {
+      id: "medical-lab",
+      name: "Medical & Lab",
+      icon: "/icons/flask_128.png",
+      isImage: true,
+      count: 67,
+      color: "from-cyan-500 to-blue-500"
+    },
+    {
+      id: "home-furniture",
+      name: "Home Furniture",
+      icon: "/icons/sofa_128.png",
+      isImage: true,
+      count: 89,
+      color: "from-amber-500 to-orange-500"
     }
   ];
 

--- a/src/pages/ModernIndex.tsx
+++ b/src/pages/ModernIndex.tsx
@@ -118,7 +118,8 @@ const ModernIndex = () => {
     {
       id: "restaurant-equipment",
       name: "Restaurant",
-      icon: UtensilsCrossed,
+      icon: "/icons/cutlery_128.png",
+      isImage: true,
       count: 189,
       color: "from-green-500 to-emerald-500"
     },
@@ -379,7 +380,7 @@ const ModernIndex = () => {
           
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
             {categories.map((category) => {
-              const IconComponent = category.icon;
+              const IconComponent = category.isImage ? null : category.icon;
               return (
                 <Link
                   key={category.id}
@@ -389,7 +390,15 @@ const ModernIndex = () => {
                   <div className={`absolute inset-0 bg-gradient-to-br ${category.color} opacity-0 group-hover:opacity-10 transition-opacity`} />
                   <div className="p-6">
                     <div className="flex justify-between items-start mb-4">
-                      <IconComponent className="h-10 w-10 text-gray-700 group-hover:text-brand-red transition-colors" />
+                      {category.isImage ? (
+                        <img 
+                          src={category.icon} 
+                          alt={`${category.name} icon`}
+                          className="h-10 w-10 object-contain"
+                        />
+                      ) : (
+                        <IconComponent className="h-10 w-10 text-gray-700 group-hover:text-brand-red transition-colors" />
+                      )}
                       {category.trending && (
                         <Badge className="badge-hot">Trending</Badge>
                       )}

--- a/src/pages/ModernIndex.tsx
+++ b/src/pages/ModernIndex.tsx
@@ -110,7 +110,8 @@ const ModernIndex = () => {
     {
       id: "construction-materials",
       name: "Construction",
-      icon: Building2,
+      icon: "/icons/bulldozer_128.png",
+      isImage: true,
       count: 342,
       color: "from-orange-500 to-red-500",
       trending: true
@@ -126,14 +127,16 @@ const ModernIndex = () => {
     {
       id: "office-furniture",
       name: "Office",
-      icon: Briefcase,
+      icon: "/icons/briefcase_128.png",
+      isImage: true,
       count: 156,
       color: "from-blue-500 to-indigo-500"
     },
     {
       id: "municipal-surplus",
       name: "Municipal",
-      icon: Wrench,
+      icon: "/icons/wrench_128.png",
+      isImage: true,
       count: 98,
       color: "from-purple-500 to-pink-500"
     }
@@ -141,14 +144,16 @@ const ModernIndex = () => {
     {
       id: "blacksmithing",
       name: "Blacksmithing",
-      icon: Anvil,
+      icon: "/icons/anvil_128.png",
+      isImage: true,
       count: 24,
       color: "from-stone-600 to-stone-800"
     },
     {
       id: "jewelry-making",
       name: "Jewelry Making",
-      icon: Diamond,
+      icon: "/icons/ring_128.png",
+      isImage: true,
       count: 41,
       color: "from-rose-500 to-pink-500"
     }


### PR DESCRIPTION
Update restaurant category icon to use `cutlery_128.png` image instead of a React icon component, and adjust rendering logic to support both image paths and icon components.

---
<a href="https://cursor.com/background-agent?bcId=bc-e533b772-db7f-4d3a-ad1a-3a73e0c25592">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e533b772-db7f-4d3a-ad1a-3a73e0c25592">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

